### PR TITLE
Don't build empty libtabix.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,22 +24,13 @@ all-recur lib-recur clean-recur cleanlocal-recur install-recur:
 
 all:$(PROG)
 
-lib:libtabix.a
-
-libtabix.a:$(LOBJS)
-		$(AR) -cru $@ $(LOBJS)
-		ranlib $@
-
-tabix:lib $(AOBJS)
-		$(CC) $(CFLAGS) -o $@ $(AOBJS) -lm $(LIBPATH) -L. -lhts -lz
-
 tabix.o: htslib/htslib/bgzf.h htslib/htslib/tbx.h tabix.cpp tabix.hpp
 		$(CPP) $(CFLAGS) -c tabix.cpp $(INCLUDES)
 
 htslib/libhts.a:
 		cd htslib && $(MAKE) lib-static
 
-tabix++:lib tabix.o main.cpp htslib/libhts.a
+tabix++:tabix.o main.cpp htslib/libhts.a
 		$(CPP) $(CFLAGS) -o $@ main.cpp tabix.o $(INCLUDES) $(LIBPATH) -lhts -lpthread -lm -lz
 
 cleanlocal:


### PR DESCRIPTION
Calling ar with no arguments is an error on Mac OS X.  Also, this looks like remains of old functionality that's no longer needed (moved to hstlib?).  

Note: this is part 1 of 3 pull requests to get VG building on Mac.  