### PR TITLE
Portability enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ tabix.o: $(HTS_HEADERS) tabix.cpp tabix.hpp
 htslib/libhts.a:
 	cd htslib && $(MAKE) lib-static
 
-tabix++: tabix.o main.cpp $(HTSLIB)
+tabix++: tabix.o main.cpp $(HTS_LIB)
 	$(CXX) $(CXXFLAGS) -o $@ main.cpp tabix.o $(INCLUDES) $(LIBPATH) \
 		-lhts -lpthread -lm -lz
 

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ CXXFLAGS?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
 INCLUDES?=	-Ihtslib
 HTS_HEADERS?=	htslib/htslib/bgzf.h htslib/htslib/tbx.h
 HTS_LIB?=	htslib/libhts.a
+LIBPATH?=	-L. -Lhtslib
 
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 PROG=		tabix++
 SUBDIRS=.
-LIBPATH=	-L. -Lhtslib
 
 .SUFFIXES:.c .o
 

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@
 CC?=		gcc
 CXX?= 		g++
 CXXFLAGS?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
+INCLUDES?=	-Ihtslib
+HTS_HEADERS?=	htslib/htslib/bgzf.h htslib/htslib/tbx.h
+HTS_LIB?=	htslib/libhts.a
 
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 PROG=		tabix++
-INCLUDES=	-Ihtslib
-HTS_HEADERS?=	htslib/htslib/bgzf.h htslib/htslib/tbx.h
 SUBDIRS=.
 LIBPATH=	-L. -Lhtslib
 
@@ -36,7 +37,7 @@ tabix.o: $(HTS_HEADERS) tabix.cpp tabix.hpp
 htslib/libhts.a:
 	cd htslib && $(MAKE) lib-static
 
-tabix++: tabix.o main.cpp htslib/libhts.a
+tabix++: tabix.o main.cpp $(HTSLIB)
 	$(CXX) $(CXXFLAGS) -o $@ main.cpp tabix.o $(INCLUDES) $(LIBPATH) \
 		-lhts -lpthread -lm -lz
 

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,47 @@
-CC=			gcc
-CPP= 		g++
-CFLAGS=		-g -Wall -O2 -fPIC #-m64 #-arch ppc
+
+# Use ?= for standardized variables to allow override from the env or
+# command-line.
+CC?=		gcc
+CXX?= 		g++
+CXXFLAGS?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
+
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 PROG=		tabix++
-INCLUDES=-Ihtslib
+INCLUDES=	-Ihtslib
 SUBDIRS=.
-LIBPATH=-L. -Lhtslib
+LIBPATH=	-L. -Lhtslib
 
 .SUFFIXES:.c .o
 
 .c.o:
-		$(CC) -c $(CFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CXXFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
 
 all-recur lib-recur clean-recur cleanlocal-recur install-recur:
-		@target=`echo $@ | sed s/-recur//`; \
-		wdir=`pwd`; \
-		list='$(SUBDIRS)'; for subdir in $$list; do \
-			cd $$subdir; \
-			$(MAKE) CC="$(CC)" DFLAGS="$(DFLAGS)" CFLAGS="$(CFLAGS)" \
-				INCLUDES="$(INCLUDES)" LIBPATH="$(LIBPATH)" $$target || exit 1; \
-			cd $$wdir; \
-		done;
+	@target=`echo $@ | sed s/-recur//`; \
+	wdir=`pwd`; \
+	list='$(SUBDIRS)'; for subdir in $$list; do \
+		cd $$subdir; \
+		$(MAKE) CC="$(CC)" DFLAGS="$(DFLAGS)" CXXFLAGS="$(CXXFLAGS)" \
+			INCLUDES="$(INCLUDES)" LIBPATH="$(LIBPATH)" $$target \
+			|| exit 1; \
+		cd $$wdir; \
+	done;
 
-all:$(PROG)
+all:	$(PROG)
 
-tabix.o: htslib/htslib/bgzf.h htslib/htslib/tbx.h tabix.cpp tabix.hpp
-		$(CPP) $(CFLAGS) -c tabix.cpp $(INCLUDES)
+tabix.o:	htslib/htslib/bgzf.h htslib/htslib/tbx.h tabix.cpp tabix.hpp
+		$(CXX) $(CXXFLAGS) -c tabix.cpp $(INCLUDES)
 
 htslib/libhts.a:
-		cd htslib && $(MAKE) lib-static
+	cd htslib && $(MAKE) lib-static
 
-tabix++:tabix.o main.cpp htslib/libhts.a
-		$(CPP) $(CFLAGS) -o $@ main.cpp tabix.o $(INCLUDES) $(LIBPATH) -lhts -lpthread -lm -lz
+tabix++:	tabix.o main.cpp htslib/libhts.a
+	$(CXX) $(CXXFLAGS) -o $@ main.cpp tabix.o $(INCLUDES) $(LIBPATH) \
+		-lhts -lpthread -lm -lz
 
 cleanlocal:
-		rm -fr gmon.out *.o a.out *.dSYM $(PROG) *~ *.a tabix.aux tabix.log tabix.pdf *.class libtabix.*.dylib libtabix.so*
-		cd htslib && $(MAKE) clean
+	rm -fr gmon.out *.o a.out *.dSYM $(PROG) *~ *.a tabix.aux tabix.log \
+		tabix.pdf *.class libtabix.*.dylib libtabix.so*
+	cd htslib && $(MAKE) clean
 
 clean:cleanlocal-recur

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-# Use ?= for standardized variables to allow override from the env or
-# command-line.
+# Use ?= to allow override from the env or command-line.
+
 CC?=		gcc
 CXX?= 		g++
 CXXFLAGS?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
@@ -8,13 +8,14 @@ CXXFLAGS?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 PROG=		tabix++
 INCLUDES=	-Ihtslib
+HTS_HEADERS?=	htslib/htslib/bgzf.h htslib/htslib/tbx.h
 SUBDIRS=.
 LIBPATH=	-L. -Lhtslib
 
 .SUFFIXES:.c .o
 
 .c.o:
-		$(CC) -c $(CXXFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
+	$(CC) -c $(CXXFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
 
 all-recur lib-recur clean-recur cleanlocal-recur install-recur:
 	@target=`echo $@ | sed s/-recur//`; \
@@ -29,13 +30,13 @@ all-recur lib-recur clean-recur cleanlocal-recur install-recur:
 
 all:	$(PROG)
 
-tabix.o:	htslib/htslib/bgzf.h htslib/htslib/tbx.h tabix.cpp tabix.hpp
-		$(CXX) $(CXXFLAGS) -c tabix.cpp $(INCLUDES)
+tabix.o: $(HTS_HEADERS) tabix.cpp tabix.hpp
+	$(CXX) $(CXXFLAGS) -c tabix.cpp $(INCLUDES)
 
 htslib/libhts.a:
 	cd htslib && $(MAKE) lib-static
 
-tabix++:	tabix.o main.cpp htslib/libhts.a
+tabix++: tabix.o main.cpp htslib/libhts.a
 	$(CXX) $(CXXFLAGS) -o $@ main.cpp tabix.o $(INCLUDES) $(LIBPATH) \
 		-lhts -lpthread -lm -lz
 


### PR DESCRIPTION

I made some changes to the Makefile that will allow the compiler, flags and a couple other things to be overridden by the environment or the "make" command line.

I took care to ensure that the default behavior of the Makefile will not change at all.

This simply allows control by the user or by a package manager doing automated builds using a different compiler, different library paths, etc.
