### PR TITLE
kstring_t allocates memory each time, so there is a very substantial

### DIFF
--- a/tabix.cpp
+++ b/tabix.cpp
@@ -5,6 +5,9 @@ Tabix::Tabix(void) { }
 Tabix::Tabix(string& file) {
     has_jumped = false;
     filename = file;
+    str.l = 0;
+    str.m = 0;
+    str.s = NULL;
     const char* cfilename = file.c_str();
     struct stat stat_tbi,stat_vcf;
     char *fnidx = (char*) calloc(strlen(cfilename) + 5, 1);
@@ -54,11 +57,11 @@ Tabix::Tabix(string& file) {
 Tabix::~Tabix(void) {
     tbx_itr_destroy(iter);
     tbx_destroy(tbx);
+    free(str.s);
 }
 
 void Tabix::getHeader(string& header) {
     header.clear();
-    kstring_t str = {0,0,0};
     while ( hts_getline(fn, KS_SEP_LINE, &str) >= 0 ) {
         if ( !str.l || str.s[0]!=tbx->conf.meta_char ) {
             break;
@@ -81,7 +84,6 @@ bool Tabix::setRegion(string& region) {
 }
 
 bool Tabix::getNextLine(string& line) {
-    kstring_t str = {0,0,0};
     if (has_jumped) {
         if (iter && tbx_itr_next(fn, tbx, iter, &str) >= 0) {
             line = string(str.s);

--- a/tabix.hpp
+++ b/tabix.hpp
@@ -15,6 +15,7 @@ class Tabix {
 
     htsFile* fn;
     tbx_t* tbx;
+    kstring_t str;
     hts_itr_t* iter;
     const tbx_conf_t *idxconf;
     int tid, beg, end;


### PR DESCRIPTION
memory leak before this patch.
After this patch the memory is gone and there will also be a lot less
allocation because assigning a char * to a string results in a copy so
we can re-use the same kstring_t

to see the leak just run ./tabix++ some.big.vcf.gz > /dev/null and watch
top.
found with @zeeev