### PR TITLE
Close htsFile in destructor

### DIFF
--- a/tabix.cpp
+++ b/tabix.cpp
@@ -72,6 +72,7 @@ Tabix::~Tabix(void) {
     tbx_itr_destroy(iter);
     tbx_destroy(tbx);
     free(str.s);
+    hts_close(fn);
 }
 
 const kstring_t * Tabix::getKstringPtr(){


### PR DESCRIPTION
Hi, I noticed that the htsFile opened in the constructor is never closed. In very particular cases (like mine), this may cause crashes since there are too many open files (unless changing the limit).